### PR TITLE
Fix #28, fix ShortString constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ShortStrings"
 uuid = "63221d1c-8677-4ff0-9126-0ff0817b4975"
 authors = ["Dai ZJ <zhuojia.dai@gmail.com>", "ScottPJones <scottjones@alum.mit.edu>",
            "Lyndon White <lyndon.white@invenialabs.co.uk>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"


### PR DESCRIPTION
This fixes the access violations that ZJ had seen, where the unsafe_load was trying to access past the end of allocated memory.
Currently, it just does the loading a byte at a time for `SubString{String}`, but that will be fixed in a later PR to use the same techniques that I used in `StrBase.jl`, i.e. to align the pointer and only make aligned 4/8 byte loads that are guaranteed to be safe, and then mask / shift.
