### PR TITLE
Fix equality for same-length comparisons with String

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ShortStrings"
 uuid = "63221d1c-8677-4ff0-9126-0ff0817b4975"
 authors = ["Dai ZJ <zhuojia.dai@gmail.com>", "ScottPJones <scottjones@alum.mit.edu>",
            "Lyndon White <lyndon.white@invenialabs.co.uk>"]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"

--- a/src/base.jl
+++ b/src/base.jl
@@ -213,7 +213,7 @@ end
 function ==(a::ShortString, b::String)
     sz = sizeof(a)
     sizeof(b) == sz || return false
-    sz == 0 || return true
+    sz == 0 && return true
     val = _swapped_str(a)
     @preserve b begin
         pnt = reinterpret(Ptr{UInt}, pointer(b))
@@ -232,7 +232,7 @@ end
 function ==(s::ShortString, b::SubString{String})
     sz = sizeof(s)
     sizeof(b) == sz || return false
-    sz == 0 || return true
+    sz == 0 && return true
     val = _swapped_str(s)
     @preserve s begin
         pnt = pointer(b)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ function basic_test(string_type, constructor, max_len)
     @test str_maxlen == short_maxlen
     @test short_maxlen == short_maxlen
     @test short_maxlen != constructor("d"^max_len)
+    @test short_maxlen != string_type("d"^max_len)
     @test short_maxlen != short_maxlen_m_1
     @test short_maxlen_m_1 != short_maxlen
     @test short_maxlen != str_maxlen_m_1


### PR DESCRIPTION
There was a logical condition flipped, and there was no test for this kind of comparison. The test has been added and the bug fixed. 