### PR TITLE
Add conversion from Symbol to ShortString

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -109,6 +109,8 @@ end
 
 ShortString{T}(s::ShortString{T}) where {T} = s
 
+ShortString(s::Symbol) where {T} = ShortString{T}(String(s))
+
 function ShortString{T}(s::ShortString{S}) where {T, S}
     sz = sizeof(s)
     check_size(T, sz)


### PR DESCRIPTION
The built in Julia method to convert from Symbols to Strings is nonallocating and is a no-op that just reuses the pointer to the interned string, so the conversion is the same as from string.