### PR TITLE
fix codeunit and isvalid so split works

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ShortStrings"
 uuid = "63221d1c-8677-4ff0-9126-0ff0817b4975"
 authors = ["Dai ZJ <zhuojia.dai@gmail.com>", "ScottPJones <scottjones@alum.mit.edu>",
            "Lyndon White <lyndon.white@invenialabs.co.uk>"]
-version = "0.3.5"
+version = "0.3.6"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"

--- a/src/base.jl
+++ b/src/base.jl
@@ -43,7 +43,9 @@ size_mask(s::ShortString{T}) where {T} = size_mask(T)
 _swapped_str(s::ShortString) = ntoh(s.size_content & ~size_mask(s))
 
 """Internal function to pick up a byte at the given index in a ShortString"""
-@inline _get_byte(s::ShortString, i::Int) = (s.size_content >>> (8*(sizeof(s) - i)))%UInt8
+@inline function _get_byte(s::ShortString{T}, i::Int) where T
+    return (s.size_content >>> (8*(sizeof(T) - i)))%UInt8
+end
 
 """
 Internal function to pick up a UInt32 (i.e. to contain 1 Char) at the given index
@@ -153,7 +155,9 @@ Base.lastindex(s::ShortString) = sizeof(s)
 Base.ncodeunits(s::ShortString) = sizeof(s)
 
 # Checks top two bits of first byte of character to see if valid position
-isvalid(s::String, i::Integer) = (0 < i <= sizeof(s)) && ((_get_byte(s, i) & 0xc0) != 0x80)
+function Base.isvalid(s::ShortString, i::Integer)
+    return (0 < i <= sizeof(s)) && ((_get_byte(s, i) & 0xc0) !== 0x80)
+end
 
 @inline function Base.iterate(s::ShortString, i::Int=1)
     0 < i <= ncodeunits(s) || return nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -134,3 +134,26 @@ end
     @test_throws ErrorException ShortString("foobar", 3)
     @test_throws ErrorException ss"foobar"b3
 end
+
+
+@testset "codeunit $T" for T in (ShortString3, ShortString7, ShortString255)
+    @test codeunit(T("abc"), 1) == 0x61
+    @test codeunit(T("abc"), 2) == 0x62
+    @test codeunit(T("abc"), 3) == 0x63
+end
+
+@testset "isvalid" begin
+    @test !isvalid(ShortString("a🍕c"), 0)
+    @test isvalid(ShortString("a🍕c"), 1)
+    @test isvalid(ShortString("a🍕c"), 2)
+    @test !isvalid(ShortString("a🍕c"), 3)
+    @test !isvalid(ShortString("a🍕c"), 4)
+    @test !isvalid(ShortString("a🍕c"), 5)
+    @test isvalid(ShortString("a🍕c"), 6)
+    @test !isvalid(ShortString("a🍕c"), 7)
+end
+
+@testset "split" begin
+    @test split(ShortString15("abc XYZ x")) == ["abc", "XYZ", "x"]
+    @test split(ShortString15("abc XYZ x")) isa Vector{SubString{ShortString15}}
+end


### PR DESCRIPTION
`split` wasn't working, because `isvalid` wasn't actually defined (and what was there was wrong).
In investigating that, i realized `codeunit` was also defined wrong.

