### PR TITLE
Made Constructor work with Symbol input without explicitly specified {T}

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -113,7 +113,8 @@ end
 
 ShortString{T}(s::ShortString{T}) where {T} = s
 
-ShortString(s::Symbol) where {T} = ShortString{T}(String(s))
+ShortString(s::Symbol) = ShortString(String(s))
+ShortString{T}(s::Symbol) where {T} = ShortString{T}(String(s))
 
 function ShortString{T}(s::ShortString{S}) where {T, S}
     sz = sizeof(s)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -136,6 +136,12 @@ end
 
     @test_throws ErrorException ShortString("foobar", 3)
     @test_throws ErrorException ss"foobar"b3
+    
+    
+    @test ShortString(:abcde) == "abcde"
+    @test ShortString(:abcde)) isa ShortString7
+    @test ShortString15(:abcde) == "abcde"
+    @test ShortString15(:abcde)) isa ShortString15
 
 
     @test ShortString7(Test.GenericString("abcde")) == "abcde"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -139,9 +139,9 @@ end
     
     
     @test ShortString(:abcde) == "abcde"
-    @test ShortString(:abcde)) isa ShortString7
+    @test ShortString(:abcde) isa ShortString7
     @test ShortString15(:abcde) == "abcde"
-    @test ShortString15(:abcde)) isa ShortString15
+    @test ShortString15(:abcde) isa ShortString15
 
 
     @test ShortString7(Test.GenericString("abcde")) == "abcde"


### PR DESCRIPTION
Now just works both for converting to the smallest possible ShortString type by writing `ShortString(:symbol)`, or an explicitly specified one (e.g. `ShortString15(:symbol)` ).

Also added tests for the constructor from symbol.