### PR TITLE
Add support for empty strings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ShortStrings"
 uuid = "63221d1c-8677-4ff0-9126-0ff0817b4975"
 authors = ["Dai ZJ <zhuojia.dai@gmail.com>", "ScottPJones <scottjones@alum.mit.edu>", "Lyndon White <lyndon.white@invenialabs.co.uk>"]
-version = "0.3.10"
+version = "0.3.11"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"

--- a/src/base.jl
+++ b/src/base.jl
@@ -320,7 +320,7 @@ If the keyword argument `types` is passed with a list (a tuple or Vector) of Uns
 types, in order of their size, then one of those types will be used.
 """
 ShortString(str::Union{String,SubString{String}}, maxlen = sizeof(str); types=def_types) =
-    get_type(maxlen, types=types)(str)
+    get_type(max(maxlen,1), types=types)(str)
 
 """
 Create a ShortString, using the smallest ShortString that can fit the string,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,9 +72,13 @@ ss = ShortString15(s)
 @test ss15"Short String!!!" === ShortString15("Short String!!!")
 @test ss7"ShrtStr" === ShortString7("ShrtStr")
 @test ss3"ss3" === ShortString3("ss3")
+@test ss"" === ShortString("")
 
 
 @testset "equality of different sized ShortStrings" begin
+    @test ShortString15("") == ShortString3("")
+    @test ShortString3("") == ShortString15("")
+
     @test ShortString15("ab") == ShortString3("ab")
     @test ShortString3("ab") == ShortString15("ab")
 
@@ -171,4 +175,12 @@ end
 @testset "split" begin
     @test split(ShortString15("abc XYZ x")) == ["abc", "XYZ", "x"]
     @test split(ShortString15("abc XYZ x")) isa Vector{SubString{ShortString15}}
+end
+
+@testset "test all default valid string sizes" begin
+    size_limit = 255
+    svec_good = [randstring(i) for i=0:size_limit]
+    @test typeof(ShortString.(svec_good)) == Vector{ShortString}
+    s_bad = randstring(size_limit + 1)
+    @test_throws ArgumentError ShortString(s_bad)
 end


### PR DESCRIPTION
I ran into an issue where empty strings would cause an error: 
```
julia> ss""
ERROR: ArgumentError: 0 is <= 0
Stacktrace:
 [1] get_type(maxlen::Int64; types::NTuple{7, DataType})
   @ ShortStrings ~/git-repos/julia_packages/ShortStrings.jl/src/base.jl:309
 [2] ShortString(str::String, maxlen::Int64; types::NTuple{7, DataType})
   @ ShortStrings ~/git-repos/julia_packages/ShortStrings.jl/src/base.jl:322
 [3] ShortString(str::String, maxlen::Int64)
   @ ShortStrings ~/git-repos/julia_packages/ShortStrings.jl/src/base.jl:322
 [4] top-level scope
   @ REPL[2]:1
```

After some brief digging I couldn't find any documented reason why empty strings shouldn't be allowed and it seemed simple enough to add support