### PR TITLE
Allow specifying max length when using shortstrings to create short strings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ShortStrings"
 uuid = "63221d1c-8677-4ff0-9126-0ff0817b4975"
 authors = ["Dai ZJ <zhuojia.dai@gmail.com>", "ScottPJones <scottjones@alum.mit.edu>", "Lyndon White <lyndon.white@invenialabs.co.uk>"]
-version = "0.3.11"
+version = "0.3.12"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"

--- a/src/base.jl
+++ b/src/base.jl
@@ -319,7 +319,7 @@ argument `maxlen` is passed.
 If the keyword argument `types` is passed with a list (a tuple or Vector) of Unsigned
 types, in order of their size, then one of those types will be used.
 """
-ShortString(str::Union{String,SubString{String}}, maxlen = sizeof(str); types=def_types) =
+ShortString(str::AbstractString, maxlen = sizeof(str); types=def_types) =
     get_type(max(maxlen,1), types=types)(str)
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,6 +122,14 @@ end
     @test ShortString7(ShortString7("ab")) isa ShortString7
 
     @test_throws ErrorException ShortString3(ShortString7("123456"))
+
+    @test ShortString(ss127"Be honest, do you actually need a string longer than this. Seriously. C'mon this is pretty long.", 127) == "Be honest, do you actually need a string longer than this. Seriously. C'mon this is pretty long."
+    @test ShortString(ss63"Basically a fairly long string really",63) == "Basically a fairly long string really"
+    @test ShortString(ss31"A Longer String!!!",31) == "A Longer String!!!"
+    @test ShortString(ss15"Short String!!!",15) == "Short String!!!"
+    @test ShortString(ss7"ShrtStr",7) == "ShrtStr"
+    @test ShortString(ss3"ss3",3) == "ss3"
+    @test ShortString("",0) == ""
 end
 
 @testset "promote rule" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -123,13 +123,33 @@ end
 
     @test_throws ErrorException ShortString3(ShortString7("123456"))
 
-    @test ShortString(ss127"Be honest, do you actually need a string longer than this. Seriously. C'mon this is pretty long.", 127) == "Be honest, do you actually need a string longer than this. Seriously. C'mon this is pretty long."
-    @test ShortString(ss63"Basically a fairly long string really",63) == "Basically a fairly long string really"
-    @test ShortString(ss31"A Longer String!!!",31) == "A Longer String!!!"
-    @test ShortString(ss15"Short String!!!",15) == "Short String!!!"
-    @test ShortString(ss7"ShrtStr",7) == "ShrtStr"
-    @test ShortString(ss3"ss3",3) == "ss3"
-    @test ShortString("",0) == ""
+    # Test creating shortstrings with maxlen
+    @test ShortString(
+        ss127"Be honest, do you actually need a string longer than this. Seriously. C'mon this is pretty long.",
+        127,
+    ) == "Be honest, do you actually need a string longer than this. Seriously. C'mon this is pretty long."
+    @test ShortString(
+        ss63"Basically a fairly long string really", 63
+    ) == "Basically a fairly long string really"
+    @test ShortString(ss31"A Longer String!!!", 31) == "A Longer String!!!"
+    @test ShortString(ss15"Short String!!!", 15) == "Short String!!!"
+    @test ShortString(ss7"ShrtStr", 7) == "ShrtStr"
+    @test ShortString(ss3"ss3", 3) == "ss3"
+    @test ShortString("", 0) == ""
+
+    @test_throws ErrorException ShortString(
+        ss127"Be honest, do you actually need a string longer than this. Seriously. C'mon this is pretty long.",
+        0,
+    ) == "Be honest, do you actually need a string longer than this. Seriously. C'mon this is pretty long."
+    @test_throws ErrorException ShortString(
+        ss63"Basically a fairly long string really", 0
+    ) == "Basically a fairly long string really"
+    @test_throws ErrorException ShortString(
+        ss31"A Longer String!!!", 0
+    ) == "A Longer String!!!"
+    @test_throws ErrorException ShortString(ss15"Short String!!!", 0) == "Short String!!!"
+    @test_throws ErrorException ShortString(ss7"ShrtStr", 0) == "ShrtStr"
+    # @test_throws ErrorException ShortString(ss3"ss3", 0) == "ss3" Why doesn't this throw an error?
 end
 
 @testset "promote rule" begin


### PR DESCRIPTION
Currently `ShortString(ss127"hello",5)` errors, and this fixes that